### PR TITLE
watertap 1.2.0

### DIFF
--- a/doctions-data/contexts/watertap.yml
+++ b/doctions-data/contexts/watertap.yml
@@ -48,6 +48,9 @@ project:
         month: 12
 
 releases:
+  1.2.0rc0:
+    next_dev_version_tag: 1.3.dev0
+    highlights: []
   '1.1.0':
     highlights:
       - Fixed a bug for enthalpy units in crystallizer property package

--- a/doctions-data/contexts/watertap.yml
+++ b/doctions-data/contexts/watertap.yml
@@ -48,6 +48,15 @@ project:
         month: 12
 
 releases:
+  1.2.0rc1:
+    highlights: []
+    refs_to_cherrypick:
+
+      # watertap-org/watertap#1466
+      - 9eb240e8f909e1c23bef3d4518349108edb4ed59
+
+      # watertap-org/watertap#1522
+      - 3d2c4a0dc2d2098103844ac1abf9461dde22902e
   1.2.0rc0:
     next_dev_version_tag: 1.3.dev0
     highlights: []

--- a/doctions-data/contexts/watertap.yml
+++ b/doctions-data/contexts/watertap.yml
@@ -48,6 +48,8 @@ project:
         month: 12
 
 releases:
+  '1.2.0':
+    highlights: []
   1.2.0rc1:
     highlights: []
     refs_to_cherrypick:

--- a/doctions-data/workflows/release.yml
+++ b/doctions-data/workflows/release.yml
@@ -30,11 +30,9 @@ jobs:
           items:
             - Open `./setup.py`
             - Search for `version=` (in the kwargs for the call to `setup()`) and set `version="${{ release.tag }}"`
-            - |
-              Search for `SPECIAL_DEPENDENCIES_FOR_RELEASE` and set it to `SPECIAL_DEPENDENCIES_FOR_RELEASE = ["idaes-pse${{ release.extra.idaes_pse_version }}"]`
-            - Search for `SPECIAL_DEPENDENCIES_FOR_PRERELEASE` and set it to `SPECIAL_DEPENDENCIES_FOR_PRERELEASE = SPECIAL_DEPENDENCIES_FOR_RELEASE`
             - Search for `install_requires=`
-            - Make sure **only** `SPECIAL_DEPENDENCIES_FOR_RELEASE` (i.e. the **FOR_RELEASE** variant) is included in `install_requires`
+            - Verify that `idaes-pse` is set to the appropriate version
+            - Verify that no URLs are present in the requirements
             - Save and exit
             - Open `./docs/conf.py`
             - Search for `version =` and set `version = "${{ release.tag }}"`


### PR DESCRIPTION
# WaterTAP: cutting release `1.2.0`

## Create and/or update `1.2_rel` release branch

- [x] **1: Clone repository in a fresh directory**

  ```sh
  pushd "$(mktemp -d)"
  git clone git@github.com:watertap-org/watertap.git && cd watertap
  ```

- [x] **2: Switch to release branch if it exists, else create it**

  ```sh
  git checkout "1.2_rel" || git checkout -b "1.2_rel"
  ```

- [ ] **3: Review differences with the default branch**
  - [ ] Go to compare URL https://github.com/watertap-org/watertap/compare/1.2_rel...main
- [x] ~~**4: Cherry-pick commits onto the release branch**~~ (N/A)
- [ ] **5: Update version and dependencies in `./setup.py` (WaterTAP, DISPATCHES)**
  - [ ] Open `./setup.py`
  - [ ] Search for `version=` (in the kwargs for the call to `setup()`) and set `version="1.2.0"`
  - [ ] Search for `install_requires=`
  - [ ] Verify that `idaes-pse` is set to the appropriate version
  - [ ] Verify that no URLs are present in the requirements
  - [ ] Save and exit
  - [ ] Open `./docs/conf.py`
  - [ ] Search for `version =` and set `version = "1.2.0"`
  - [ ] Search for `release =` and set `release = "1.2.0"`
  - [ ] Save and exit
  - [ ] `git add setup.py docs/conf.py`
- [x] ~~**6: Update version and dependencies (FOQUS)**~~ (N/A)
- [x] ~~**7: Update version (IDAES)**~~ (N/A)
- [x] ~~**8: Update version (IDAES examples)**~~ (N/A)
- [x] ~~**9: Update version (IDAES UI)**~~ (N/A)
- [x] ~~**10: Update version (IDAES examples-pse)**~~ (N/A)
- [x] ~~**11: Update version and dependencies in `./setup.py` (PARETO)**~~ (N/A)
- [x] **12: Check that the local modifications to the version are as they should**

  ```sh
  git status      # there shouldn't be any other unstaged files
  git status -vv  # the changes with the version should be there
  ```

- [x] **13: Commit the changes to the `1.2_rel` branch**

  ```sh
  # check that we're on the correct release branch
  test "$(git branch --show-current)" = "1.2_rel" && git commit -m "1.2.0" --allow-empty
  ```

- [x] **14: Review the changes before pushing**

  ```sh
  git log --oneline -n 5  # it should show only one commit which is not pushed
  git push --set-upstream git@github.com:watertap-org/watertap.git "1.2_rel" --dry-run
  ```

- [ ] **15: Push the changes**

  ```sh
  git push --set-upstream git@github.com:watertap-org/watertap.git "1.2_rel"
  ```

## ~~Updating default branch with next dev version~~ (N/A)

## Creating the GitHub release

- [ ] **1: Generate release notes and create GitHub draft release**
  Copy and paste the following release notes into a file named `release-notes-1.2.0.md`:

  ```markdown
  # 1.2 Release

  Start with our [online documentation](https://watertap.readthedocs.org/en/1.2.0) to get started with install instructions, examples, etc.

  ## WaterTAP 1.2.0 Release Highlights

  ```

  Or, run the following shell command to create the file in the local directory:

  ```sh
  cat <<'EOF' > release-notes-1.2.0.md
  # 1.2 Release

  Start with our [online documentation](https://watertap.readthedocs.org/en/1.2.0) to get started with install instructions, examples, etc.

  ## WaterTAP 1.2.0 Release Highlights


  EOF
  ```

  Run this command to create a draft release using the `gh` CLI tool

  ```sh
  gh release create "1.2.0" --repo "watertap-org/watertap" --target "1.2_rel" --title "1.2 Release" --notes-file "release-notes-1.2.0.md" --draft
  ```

- [x] ~~**2: Create a ZIP file for the examples and attach it to the release as an asset**~~ (N/A)
- [x] ~~**3: Update the compatibility file on `main`**~~ (N/A)
- [ ] **4: Check that the GitHub release was created successfully**
  - [ ] Go to https://github.com/watertap-org/watertap/releases/tag/1.2.0
  - [ ] If "Draft", click on https://github.com/watertap-org/watertap/releases/edit/1.2.0 to remove the "Draft" marker
- [ ] **5: Check that the release tag has been created in the repo**

  ```sh
  curl -sL https://github.com/watertap-org/watertap/archive/1.2.0.zip | sha256sum
  ```

  > **NOTE**
  > - The release needs to be undrafted for this to work
  > - Use `wget` if `curl -sL` doesn't work

## Deleting the release (if needed)

- [ ] **1: Delete the release on GitHub**

  ```sh
  # add the --yes flag to skip confirmation prompt
  gh release delete --repo watertap-org/watertap "1.2.0"
  ```

- [ ] **2: Delete the tag on the remote**

  ```sh
  pushd "$(mktemp -d)"
  git clone --depth 1 --branch "1.2_rel" https://github.com/watertap-org/watertap && cd watertap
  git push --delete git@github.com:watertap-org/watertap.git "refs/tags/1.2.0"
  ```

- [ ] **3: Delete the tag locally**

  ```sh
  git tag --delete "1.2.0"
  ```

## Checking the docs (ReadTheDocs)

- [ ] **1: Check the ReadTheDocs build**
  - [ ] Go to https://www.readthedocs.org/projects/watertap/builds and check that the build for `1.2.0` has been run successfully
  - [ ] If not, edit the version at https://www.readthedocs.org/dashboard/watertap/version/1.2.0/edit so that it starts building
  - [ ] If the previous step didn't work, go to https://www.readthedocs.org/projects/watertap/versions, search for the `1.2.0` version, and click on "Edit"
- [ ] **2: Check that the `1.2.0` tag is available on ReadTheDocs**
  - [ ] Manually, at https://watertap.readthedocs.org/en/1.2.0
  - [ ] `curl -sL "https://watertap.readthedocs.org/en/1.2.0" | grep "/1.2.0/"`
  - [ ] `curl -sL "https://watertap.readthedocs.org/en/1.2.0" | grep "Versions" --after 10 | grep "/1.2.0/"`
- [ ] **3: Check that the ReadTheDocs revision (commit) on `latest` matches the release tag**

  ```sh
  curl -sL "https://watertap.readthedocs.org/en/1.2.0" | grep "Revision"
  curl -sL "https://watertap.readthedocs.org/en/latest" | grep "Revision"
  curl -sL "https://watertap.readthedocs.org" | grep "Revision"
  ```

- [ ] **4: Check that the ReadTheDocs revision (commit) on `stable` matches the release tag**

  ```sh
  curl -sL "https://watertap.readthedocs.org/en/1.2.0" | grep "Revision"
  curl -sL "https://watertap.readthedocs.org/en/stable" | grep "Revision"
  ```

## Creating the `watertap` Python package distribution

- [ ] **1: Trigger the PyPI workflow using `gh workflow run`**

  ```sh
  gh workflow run -R lbianchi-lbl/pse-releng release-watertap.yml -F phase=pypi -F tag=1.2.0
  ```

## ~~Creating the `watertap` Python package distribution~~ (N/A)

## ~~Build and deploy examples using containers~~ (N/A)

## ~~Build and deploy examples~~ (N/A)

## Collect environment info for the release from env-snapshot workflow

- [ ] **1: Download workflow artifact and upload as release artifact**

  ```sh
  # bash/zsh
  pushd "$(mktemp -d)"
  artifact_name="watertap-1.2.0"
  gh run download -R lbianchi-lbl/pse-releng -n "$artifact_name" -D "$artifact_name"
  gh release upload --repo "watertap-org/watertap" "1.2.0" $artifact_name/*
  ```

## ~~Collect environment info for the release~~ (N/A)

## Announce the release

- [ ] **1: Internally**
  Summary text (in `markdown`):

  ```markdown
  Release 1.2.0 is up!

  - GitHub: https://github.com/watertap-org/watertap/releases/tag/1.2.0
  - PyPI: https://pypi.org/project/watertap/1.2.0/
  - ReadTheDocs: https://watertap.readthedocs.org/en/1.2.0
  ```

  ---
  Release 1.2.0 is up!

  - GitHub: https://github.com/watertap-org/watertap/releases/tag/1.2.0
  - PyPI: https://pypi.org/project/watertap/1.2.0/
  - ReadTheDocs: https://watertap.readthedocs.org/en/1.2.0
  ---
- [ ] **2: Announce the release**
  - [ ] Via an email to the leadership, lab and users list (**TODO**: add template)